### PR TITLE
feat: set bufname

### DIFF
--- a/lua/messages/api.lua
+++ b/lua/messages/api.lua
@@ -8,6 +8,7 @@ M.open_float = function(text)
   local winnr = settings.prepare_buffer(settings.buffer_opts(lines))
   vim.api.nvim_buf_set_lines(vim.fn.bufnr(), 0, -1, true, lines)
   settings.post_open_float(winnr)
+  vim.api.nvim_buf_set_name(0, settings.buffer_name)
   return winnr
 end
 

--- a/lua/messages/api.lua
+++ b/lua/messages/api.lua
@@ -6,9 +6,13 @@ local settings = require('messages.config').settings
 M.open_float = function(text)
   local lines = vim.split(text, '\n')
   local winnr = settings.prepare_buffer(settings.buffer_opts(lines))
-  vim.api.nvim_buf_set_lines(vim.fn.bufnr(), 0, -1, true, lines)
+  local bufnr = vim.fn.bufnr()
+
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, true, lines)
+  vim.api.nvim_buf_set_name(bufnr, settings.buffer_name)
+  vim.api.nvim_buf_set_option(bufnr, 'bufhidden', 'delete')
+
   settings.post_open_float(winnr)
-  vim.api.nvim_buf_set_name(0, settings.buffer_name)
   return winnr
 end
 

--- a/lua/messages/config.lua
+++ b/lua/messages/config.lua
@@ -5,6 +5,7 @@ local M = {}
 M.settings = {
   command_name = 'Messages',
   border = 'rounded',
+  buffer_name = 'messages',
   -- should prepare a new buffer and return the winid
   -- by default opens a floating window
   -- provide a different callback to change this behaviour


### PR DESCRIPTION
Sets the `bufname` of the window.

I also added a fix so that the `:Messages` buffer is cleaned up after its window has been closed.