### PR TITLE
fix: use `nvim_exec2` instead of deprecated `nvim_exec`

### DIFF
--- a/lua/messages/api.lua
+++ b/lua/messages/api.lua
@@ -25,7 +25,7 @@ M.capture_cmd = function(cmd)
     cmd = 'messages'
   end
 
-  M.open_float(vim.api.nvim_exec(cmd, true))
+  M.open_float(vim.api.nvim_exec2(cmd, { output = true }).output)
 end
 
 return M


### PR DESCRIPTION
`nvim_exec` is deprecated since nvim 0.9